### PR TITLE
unable to authenticate with demo user from fixtures

### DIFF
--- a/fixtures/Story/DemoStory.php
+++ b/fixtures/Story/DemoStory.php
@@ -27,7 +27,7 @@ final class DemoStory extends Story
     public function build(): void
     {
         // create a user
-        UserFactory::createOne(['identifier' => 'demo@demo.fr', 'password' => 'demo1234%']);
+        UserFactory::createOne(['identifier' => 'demo@demo.fr', 'plainPassword' => 'demo1234%']);
 
         // create few events
         EventFactory::new()->sequence([


### PR DESCRIPTION
https://github.com/dogstronauts/astrobook/issues/34 Update the fixture to use the plainPassword field instead of password when creating the user

**Dogstronauts\AstroBook\Fixtures\Story\DemoStory.php**
```
// create a user
UserFactory::createOne(['identifier' => 'demo@demo.fr', 'plainPassword' => 'demo1234%']);
```
