### PR TITLE
resolve deprecated message for zenstruck foundry

### DIFF
--- a/config/packages/zenstruck_foundry.php
+++ b/config/packages/zenstruck_foundry.php
@@ -26,6 +26,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'make_story' => [
                 'default_namespace' => 'Dogstronauts\AstroBook\Fixtures\Story',
             ],
+            'enable_auto_refresh_with_lazy_objects' => true,
         ]);
     }
 };


### PR DESCRIPTION
Since zenstruck/foundry 2.7: Not setting a value for "zenstruck_foundry.enable_auto_refresh_with_lazy_objects" is deprecated. This option will be forced to true in 3.0.